### PR TITLE
Add config object to FiddlerProxy plugin to be able to set Fiddler URL

### DIFF
--- a/plugins/fiddler-proxy.js
+++ b/plugins/fiddler-proxy.js
@@ -2,7 +2,7 @@
 var url = require('url');
 var tunnelAgent = require('tunnel-agent');
 
-var FIDDLER_URL = 'http://127.0.0.1:8888';
+var DEFAULT_FIDDLER_URL = 'http://127.0.0.1:8888';
 
 var allowedHeaders = [
   'accept',
@@ -37,7 +37,6 @@ var onlyHeaders = [
   'proxy-authorization'
 ];
 
-var proxy = url.parse(FIDDLER_URL);
 
 function makeProxyHeaders(headers) {
   return Object.keys(headers)
@@ -61,7 +60,7 @@ function getAgentFactory(targetProtocol, proxyProtocol) {
   return agentFactories[targetProtocol + proxyProtocol].bind(tunnelAgent);
 }
 
-function addFiddlerProxy(conf) {
+function addFiddlerProxy(conf, proxy) {
   if (process.env.USE_FIDDLER) {
     conf.agent = getAgentFactory(conf.port === 443 ? 'https:' : 'http:', proxy.protocol)({
       proxy: {
@@ -76,9 +75,14 @@ function addFiddlerProxy(conf) {
   return conf;
 }
 
-module.exports = function FiddlerProxyPlugin(client) {
-  var previous = client.requestTransform || function identity(x) { return x; };
-  client.requestTransform = function(conf) {
-    return addFiddlerProxy(previous(conf));
+module.exports = function(opts) {
+  opts = opts || { url: DEFAULT_FIDDLER_URL };
+  var proxy = url.parse(opts.url);
+  
+  return function FiddlerProxyPlugin(client) {
+    var previous = client.requestTransform || function identity(x) { return x; };
+    client.requestTransform = function(conf) {
+      return addFiddlerProxy(previous(conf), proxy);
+    };
   };
 };


### PR DESCRIPTION
Provided changes to FiddlerProxy plugin might be helpful when using Fiddler not on the local machine. For example, developing on mac, you might want to use fiddler on the windows machine running inside a VM like VMWare Fusion or Parallels Desktop. (Telerik provided instructions on how to set up such workflow: http://goo.gl/pdgQBa).

Assuming the current PR the plugin call signature would be the following:

```javascript
//default fiddler url, e.g http://127.0.0.1:8888
client.plugins = [FiddlerProxy()];

//custom fiddler url
client.plugins = [FiddlerProxy({ url: 'http://192.168.1.37:8888' })];
```