### PR TITLE
Updated SHA256 Validation Utilities

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -49,7 +49,8 @@ module.exports = {
     MASTERCATALOG: 'master-catalog',
     CATALOG: 'catalog',
     DATAVIEWMODE: 'dataview-mode',
-    VERSION: 'version'
+    VERSION: 'version',
+    SHA256: 'hmac-sha256'
   },
   dataViewModes: {
     LIVE: 'Live',

--- a/security/hash-stream.js
+++ b/security/hash-stream.js
@@ -8,7 +8,7 @@ function makeHashStream() {
   return h;
 }
 
-module.exports = function hashStream(secretKey, date) {
+module.exports = function hashStream(secretKey, date, body) {
   var hash1 = makeHashStream();
   var hash2 = makeHashStream();
 
@@ -19,6 +19,8 @@ module.exports = function hashStream(secretKey, date) {
   hash2.write(sha256key);
 
   hash2.write(date);
+
+  hash2.write(body);
 
   return hash2;
 };

--- a/security/is-request-valid.js
+++ b/security/is-request-valid.js
@@ -3,21 +3,20 @@
 var hashStream = require('./hash-stream'),
     concat = require('concat-stream'),
     constants = require('../constants'),
-    url = require('url'),
     util = require('util'),
     defaultTimeout = constants.capabilityTimeoutInSeconds;
 
 module.exports = function isRequestValid(context, req, cb) {
   var timeout = context.capabilityTimeoutInSeconds || defaultTimeout;
-  var uri = url.parse(req.url, true),
-      queryString = uri.query,
-      requestDate = new Date(queryString.dt),
+  var headers = req.headers,
+      body = JSON.stringify(req.body),
+      requestDate = new Date(headers.date),
       currentDate = new Date(),
       diff = (currentDate - requestDate) / 1000;
 
-  req.pipe(hashStream(context.sharedSecret, queryString.dt)).pipe(concat(function (hash) {
-    if (hash !== queryString.messageHash || diff > timeout) {
-      return cb(new Error(util.format("Unauthorized access from %s, %s, %s Computed: %s", req.headers.host, queryString.messageHash, queryString.dt, hash)));
+  req.pipe(hashStream(context.sharedSecret, headers.date, body)).pipe(concat(function (hash) {
+    if (hash !== headers[constants.headerPrefix + constants.headers['SHA256']] || diff > timeout) {
+      return cb(new Error(util.format("Unauthorized access from %s, %s, %s Computed: %s", headers.host, headers[constants.headerPrefix + constants.headers['SHA256']], headers.date, hash)));
     } else {
       return cb(null);
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -48,7 +48,8 @@ module.exports = {
     MASTERCATALOG: 'master-catalog',
     CATALOG: 'catalog',
     DATAVIEWMODE: 'dataview-mode',
-    VERSION: 'version'
+    VERSION: 'version',
+    SHA256: 'hmac-sha256'
   },
   dataViewModes: {
     LIVE: 'Live',

--- a/src/security/hash-stream.js
+++ b/src/security/hash-stream.js
@@ -7,7 +7,7 @@ function makeHashStream() {
   return h;
 }
 
-module.exports = function hashStream(secretKey, date) {
+module.exports = function hashStream(secretKey, date, body) {
   var hash1 = makeHashStream();
   var hash2 = makeHashStream();
   
@@ -18,6 +18,8 @@ module.exports = function hashStream(secretKey, date) {
   hash2.write(sha256key);
 
   hash2.write(date);
+  
+  hash2.write(body);
 
   return hash2;
 };


### PR DESCRIPTION
I refactored the SHA256 hash-stream.js utility to now add in a hash of the stringified request.body. I added a SHA256 constant to the headers in constants.js. And finally, I refactored is-request-valid.js to pull the date from request.headers, as well the headerPrefix and the SHA256 header constant to pull the SHA hash from the request.headers.