### PR TITLE
Use NodeJS idioms for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ before_script:
 - git config --global user.email "travis-ci-build@volusion.com"
 - git config --global user.name "Travis CI Build"
 script:
-- node --version
-- npm --version
 - if [ -n "TRAVIS_TAG" ]; then npm run ci-build-stable; else npm run ci-build; fi
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,15 @@
-language: objective-c
-os:
-- linux
-- osx
+language: node_js
 sudo: false
 branches:
   except:
   - /^v[0-9]/
-env:
-  matrix:
-  - TRAVIS_NODE_VERSION="0.12"
-  - TRAVIS_NODE_VERSION="4.1"
-  - TRAVIS_NODE_VERSION="4.2"
-  - TRAVIS_NODE_VERSION="stable"
-cache:
-  directories:
-  - node_modules
+node_js:
+- "0.12"
+- "4.1"
+- "4.2"
+- "stable"
+cache: npm
 before_script:
-- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
-  && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm
-  install $TRAVIS_NODE_VERSION
-- npm install -g npm
-- npm install
 - git config --global user.email "travis-ci-build@volusion.com"
 - git config --global user.name "Travis CI Build"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-sudo: false
+dist: xenial
 branches:
   except:
   - /^v[0-9]/


### PR DESCRIPTION
- Sets language from `objective-c` to `node_js`.
- Removes `os` entries, because it should work the same on Linux or OSX.
- Uses `node_js` matrix key to specify versions.
- Uses `npm` cache strategy.
- Removes redundant steps under `script` that installed the latest version of npm (because those steps had been failing).