### PR TITLE
fix bug in tenant cache

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -51,8 +51,11 @@ module.exports = {
     CATALOG: 'catalog',
     DATAVIEWMODE: 'dataview-mode',
     VERSION: 'version',
-    SHA256: 'hmac-sha256'
+    SHA256: 'hmac-sha256',
+    JWT: 'jwt'
   },
+  jwtHeader: 'Authorization',
+  jwtHeaderValuePrefix: 'Bearer ',
   dataViewModes: {
     LIVE: 'Live',
     PENDING: 'Pending'

--- a/src/utils/deep-clone.js
+++ b/src/utils/deep-clone.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  deepClone: function deepClone (inObj) {
+    let outObj, key, val;
+    
+    if (typeof inObj !== 'object' || inObj === null) return inObj;
+    
+    outObj = inObj instanceof Array ? [] : Object.create(Object.getPrototypeOf(inObj));
+    
+    for (key in inObj) {
+      if (Object.prototype.hasOwnProperty.call(inObj, key)) {
+        val = inObj[key];      
+        outObj[key] = deepClone(val);
+      }
+    }
+  
+    return outObj;
+  }
+}

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -21,7 +21,13 @@ function makeHeaders(conf, payload) {
   var headers;
   function iterateHeaders(memo, key) {
     if (conf.context[constants.headers[key]]) {
-      memo[constants.headerPrefix + constants.headers[key]] = conf.context[constants.headers[key]];
+      if (key === 'JWT') {
+        memo[constants.jwtHeader] = conf.context[constants.headers[key]].indexOf(constants.jwtHeaderValuePrefix) === -1 ?
+          constants.jwtHeaderValuePrefix + conf.context[constants.headers[key]] :
+          conf.context[constants.headers[key]];
+      } else {
+        memo[constants.headerPrefix + constants.headers[key]] = conf.context[constants.headers[key]];
+      }
     }
     return memo;
   }

--- a/src/utils/tenant-cache.js
+++ b/src/utils/tenant-cache.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const deepClone = require('./deep-clone');
+
 let TenantClient;
 let TenantsOrPromisesById = {};
 
@@ -20,8 +22,11 @@ module.exports = {
       }
       return tenant;
     } else {
-      return TenantsOrPromisesById[tenantId] =
-        (new TenantClient(client)).getTenant(null, { scope: scope });
+      let newClient = deepClone(client);
+      if (newClient.context['user-claims']) {
+        delete newClient.context['user-claims'];
+      }
+      return TenantsOrPromisesById[tenantId] = new TenantClient(newClient).getTenant(null, { scope: scope });
     }
   }
 };


### PR DESCRIPTION
fixing a bug in the tenant cache wherein a user-claims is passed to the original client, and subsequently passed into the call to getTenant, which causes getTenant to fail due to the shopper not having proper permissions