### PR TITLE
fix(esbuild): do not use lazy require

### DIFF
--- a/security/auth-provider.js
+++ b/security/auth-provider.js
@@ -9,16 +9,9 @@ var TenantCache = require('../utils/tenant-cache');
 
 // if (typeof Promise !== "function") require('when/es6-shim/Promise.browserify-es6');
 
-function createMemoizedClientFactory(clientPath) {
-  var c;
-  return function () {
-    return (c || (c = require(clientPath))).apply(this, arguments);
-  };
-}
-
-var makeAppAuthClient = createMemoizedClientFactory('../clients/platform/applications/authTicket');
-var makeDeveloperAuthClient = createMemoizedClientFactory('../clients/platform/developer/developerAdminUserAuthTicket');
-var makeAdminUserAuthClient = createMemoizedClientFactory('../clients/platform/adminuser/tenantAdminUserAuthTicket');
+var makeAppAuthClient = require('../clients/platform/applications/authTicket');
+var makeDeveloperAuthClient = require('../clients/platform/developer/developerAdminUserAuthTicket');
+var makeAdminUserAuthClient = require('../clients/platform/adminuser/tenantAdminUserAuthTicket');
 
 function cacheDataAndCreateAuthTicket(res) {
   var tenants = res.availableTenants;

--- a/src/security/auth-provider.js
+++ b/src/security/auth-provider.js
@@ -9,16 +9,9 @@ let TenantCache = require('../utils/tenant-cache');
 
 // if (typeof Promise !== "function") require('when/es6-shim/Promise.browserify-es6');
 
-function createMemoizedClientFactory(clientPath) {
-  var c;
-  return function() {
-    return (c || (c = require(clientPath))).apply(this, arguments);
-  };
-}
-
-var makeAppAuthClient = createMemoizedClientFactory('../clients/platform/applications/authTicket');
-var makeDeveloperAuthClient = createMemoizedClientFactory('../clients/platform/developer/developerAdminUserAuthTicket');
-var makeAdminUserAuthClient = createMemoizedClientFactory('../clients/platform/adminuser/tenantAdminUserAuthTicket');
+var makeAppAuthClient = require('../clients/platform/applications/authTicket');
+var makeDeveloperAuthClient = require('../clients/platform/developer/developerAdminUserAuthTicket');
+var makeAdminUserAuthClient = require('../clients/platform/adminuser/tenantAdminUserAuthTicket');
 
 function cacheDataAndCreateAuthTicket(res) {
   let tenants = res.availableTenants;


### PR DESCRIPTION
There is a problem with an SDK when using it with esbuild tool. The main problem that there is something called `createMemoizedClientFactory` that uses dynamic require, which is not supported by esbuild. I looked into the code and found that this function is essentially useless, since `require` itself is doing caching.

<img width="708" alt="Screenshot 2022-11-07 at 20 49 34" src="https://user-images.githubusercontent.com/44979703/200390685-2792c2a3-6a3a-4634-b1fb-81c330311c4e.png">

tests are running locally, all passing

So by merging this, we will first - remove redundant code, second - support esbuild.

A little bit more info about my testing lab:

```demo.ts
// @ts-ignore
import createKiboApi from 'mozu-node-sdk/clients/platform/application';
// @ts-ignore
import createOrderApi from 'mozu-node-sdk/clients/commerce/order';

const apiContext = createKiboApi({
  context: {
    appKey: '[REDUCTED]',
    sharedSecret: '[REDUCTED]',
    tenant: [REDUCTED],
    site: [REDUCTED],
    baseUrl: 'https://home.mozu.com',
  },
});

const kiboOrderService = createOrderApi(apiContext);

kiboOrderService
  .getOrder({ orderId: '[REDUCTED]' })
  .then(console.log);

```

and run it via 

```sh
npx esbuild demo.ts --bundle --outfile=out.js --platform=node && node out.js
```

My node version:

<img width="183" alt="Screenshot 2022-11-07 at 20 52 33" src="https://user-images.githubusercontent.com/44979703/200391247-4c717e08-bf36-416f-ae08-d5dba1a359f1.png">

If i run code above right now, it will give me
<img width="823" alt="Screenshot 2022-11-07 at 20 53 37" src="https://user-images.githubusercontent.com/44979703/200391426-de83e82f-1135-4937-9e93-62b329a5a145.png">

With fix applied, works just fine. (even though we have some warning in the console)
<img width="830" alt="Screenshot 2022-11-07 at 20 53 49" src="https://user-images.githubusercontent.com/44979703/200391466-36bf9d10-4469-40ed-9c68-4984b4eb2ade.png">
